### PR TITLE
Add a case that blow up google_dense_hash_map

### DIFF
--- a/src/template.c
+++ b/src/template.c
@@ -25,7 +25,7 @@ char * new_string_from_integer(int num)
 int main(int argc, char ** argv)
 {
     int num_keys = atoi(argv[1]);
-    int i, value = 0;
+    int i, value = 0, key;
 
     if(argc <= 2)
         return 1;
@@ -76,6 +76,16 @@ int main(int argc, char ** argv)
         before = get_time();
         for(i = 0; i < num_keys; i++)
             DELETE_STR_FROM_HASH(new_string_from_integer(i));
+    }
+
+    else if (!strcmp(argv[2], "gapinsert"))
+    {
+        for(i = 0; i < num_keys; i++)
+        {
+            key = (i << 10) | (i & 1023);
+            INSERT_INT_INTO_HASH(key, value);
+            value++;
+        }
     }
 
     double after = get_time();


### PR DESCRIPTION
Here is a case that `google_dense_hash_map` use much more time than `stl_unordered_map`.
Key is generated simply by `(i << 10) | (i & 1023)` where `i` increase from 1.

```
gapinsert,1000000,stl_unordered_map,53964800,0.142443
gapinsert,1000000,google_dense_hash_map,47181824,5.537036
gapinsert,1100000,stl_unordered_map,65916928,0.128728
gapinsert,1100000,google_dense_hash_map,80736256,7.489668
gapinsert,1200000,stl_unordered_map,69160960,0.135847
gapinsert,1200000,google_dense_hash_map,80736256,8.094367
gapinsert,1300000,stl_unordered_map,72269824,0.141389
gapinsert,1300000,google_dense_hash_map,80736256,8.793521
gapinsert,1400000,stl_unordered_map,75513856,0.150329
gapinsert,1400000,google_dense_hash_map,80736256,9.628102
gapinsert,1500000,stl_unordered_map,78757888,0.229699
gapinsert,1500000,google_dense_hash_map,80736256,10.818993
gapinsert,1600000,stl_unordered_map,81866752,0.168996
gapinsert,1600000,google_dense_hash_map,80736256,11.671272
gapinsert,1700000,stl_unordered_map,85110784,0.243634
gapinsert,1700000,google_dense_hash_map,80736256,12.563268
gapinsert,1800000,stl_unordered_map,88354816,0.264759
gapinsert,1800000,google_dense_hash_map,80736256,13.661313
gapinsert,1900000,stl_unordered_map,91463680,0.271045
gapinsert,1900000,google_dense_hash_map,80736256,14.876894
gapinsert,2000000,stl_unordered_map,94707712,0.194570
gapinsert,2000000,google_dense_hash_map,80736256,16.059781
```